### PR TITLE
Add path-aware argument resolution for link and unlink commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ dloom link vim
 # Link multiple packages
 dloom link vim tmux bash
 
+# Link all packages in the current dotfiles directory
+dloom link .
+
+# Link all packages from a specific dotfiles directory
+dloom link ~/projects/dotfiles/
+
 # Link with verbose output
 dloom -v link vim
 
@@ -123,6 +129,9 @@ To remove the symlinks created by `dloom`, use the `unlink` command:
 ```bash
 # Unlink all dotfiles from your vim package
 dloom unlink vim
+
+# Unlink all packages in the current dotfiles directory
+dloom unlink .
 ```
 
 Unlink will only remove links if they were created by `dloom`, i.e - if the links are pointing to files in the source (usually the dotfiles) directory. Any extra files in the target directory will remain untouched. If `dloom` finds any backups for files that were unlinked, it will restore them. Finally, if the target directory becomes empty after unlinking (and if no backups were found), the directory will be removed. 
@@ -243,6 +252,12 @@ For a more complete example, check the [examples](https://github.com/dloomorg/dl
 # Basic linking
 dloom link <package>...
 
+# Link all packages in the current directory
+dloom link .
+
+# Link all packages from a specific directory
+dloom link ~/dotfiles/
+
 # Link with options
 dloom -v -f link <package>...  # Verbose and force overwrite
 
@@ -255,6 +270,9 @@ dloom -d link link tmux vim
 ```bash
 # Remove symlinks
 dloom unlink <package>...
+
+# Unlink all packages in the current directory
+dloom unlink .
 
 # Unlink with options
 dloom -d unlink <package>...  # Dry run (preview only)
@@ -291,6 +309,7 @@ dloom/
 │   ├── config.go       # Configuration handling
 │   ├── link.go         # Link implementation
 │   ├── unlink.go       # Unlink implementation
+│   ├── resolve.go      # Argument resolution and package enumeration
 │   └── setup.go        # System setup implementation
 └── examples/           # Sample configurations
 ```

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -7,16 +7,32 @@ import (
 )
 
 var linkCmd = &cobra.Command{
-	Use:   "link [packages...]",
+	Use:   "link [packages/paths...]",
 	Short: "Create symlinks for specified packages",
+	Long: `Create symlinks for specified packages.
+
+Arguments can be package names (e.g., vim, zsh) or paths:
+  dloom link vim zsh        # Link specific packages
+  dloom link .              # Link all packages in the current directory
+  dloom link ~/dotfiles/    # Link all packages from a specific directory`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return errors.New("no packages specified for link command")
 		}
 
+		packages, effectiveCfg, err := internal.ResolveArgs(args, cfg, logger)
+		if err != nil {
+			return err
+		}
+
+		if len(packages) == 0 {
+			logger.LogWarning("No packages found to link")
+			return nil
+		}
+
 		opts := internal.LinkOptions{
-			Config:   cfg,
-			Packages: args,
+			Config:   effectiveCfg,
+			Packages: packages,
 		}
 
 		return internal.LinkPackages(opts, logger)

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -7,16 +7,32 @@ import (
 )
 
 var unlinkCmd = &cobra.Command{
-	Use:   "unlink [packages...]",
+	Use:   "unlink [packages/paths...]",
 	Short: "Remove symlinks for specified packages",
+	Long: `Remove symlinks for specified packages.
+
+Arguments can be package names (e.g., vim, zsh) or paths:
+  dloom unlink vim zsh        # Unlink specific packages
+  dloom unlink .              # Unlink all packages in the current directory
+  dloom unlink ~/dotfiles/    # Unlink all packages from a specific directory`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return errors.New("no packages specified for unlink command")
 		}
 
+		packages, effectiveCfg, err := internal.ResolveArgs(args, cfg, logger)
+		if err != nil {
+			return err
+		}
+
+		if len(packages) == 0 {
+			logger.LogWarning("No packages found to unlink")
+			return nil
+		}
+
 		opts := internal.UnlinkOptions{
-			Config:   cfg,
-			Packages: args,
+			Config:   effectiveCfg,
+			Packages: packages,
 		}
 
 		return internal.UnlinkPackages(opts, logger)

--- a/docs/path-resolution-review.md
+++ b/docs/path-resolution-review.md
@@ -1,0 +1,89 @@
+# Path-Aware Argument Resolution — Review Document
+
+## The Problem
+
+`dloom link` treated all arguments as bare package names (subdirectory names within `source_dir`). This broke in two scenarios:
+
+1. **`dloom link .`** — `GetSourcePath(".")` resolved to `source_dir` itself, walking the entire dotfiles root as a single flat package. All `link_overrides` configs were ignored because the package name was `.`, not actual package names like `vim` or `zsh`.
+
+2. **`dloom link ~/projects/dotfiles/`** — The full path was concatenated as `filepath.Join(source_dir, "~/projects/dotfiles/")`, producing a nonsensical path that didn't exist.
+
+## Design Decision
+
+After researching how GNU Stow handles this (stow also uses packages-as-directories, requires explicit package names, has no flat mode), we decided:
+
+- **Packages are the only unit of linking** — same mental model as stow
+- **`dloom link .` means "link all packages"** — enumerate subdirectories in source_dir
+- **Root-level files are skipped** with an info message — users should organize into package directories
+- **No `--flat` or `-p` flag needed** — keeps the interface simple
+- **Absolute paths** (`/abs/path`, `~/path`) are treated as external dotfiles roots and enumerated
+- **Relative paths** (`./vim`, `vim/`) within source_dir extract the package name
+
+## Plan
+
+Introduce an argument resolution layer (`internal/resolve.go`) between the CLI commands and the internal link/unlink logic. Arguments are classified as either **bare names** or **paths**, resolved into a clean list of package names, then passed to the existing `LinkPackages`/`UnlinkPackages` functions unchanged.
+
+### Resolution rules
+
+| Argument type | Example | Resolution |
+|---|---|---|
+| Bare name | `vim`, `zsh` | Pass through as package name (unchanged behavior) |
+| `.` | `dloom link .` | Resolves to source_dir → enumerate all package directories |
+| Relative path | `./vim`, `vim/` | Child of source_dir → extract relative name as package |
+| Absolute/home path | `/abs/path`, `~/dotfiles/` | External dotfiles root → load config from there, enumerate |
+| Non-existent path | `/no/such/dir` | Error |
+
+## Implementation Tasks
+
+| # | Task | Status | Details |
+|---|------|--------|---------|
+| 1 | Create `internal/resolve.go` | DONE | `ClassifyArg()`, `ResolveArgs()`, `EnumeratePackages()`, `isSubdirOf()`, `isAbsoluteArg()`, `shouldIgnoreName()`. Handles symlink resolution (macOS `/var` → `/private/var`). |
+| 2 | Create `internal/resolve_test.go` | DONE | 16 tests: `TestClassifyArg` (12 cases), `TestEnumeratePackages` (3 variants), `TestResolveArgs_*` (10 scenarios including dot, subdir, external with/without config, dedup, trailing slash, conflicts, not-a-directory), `Test_isSubdirOf` (5 cases). |
+| 3 | Modify `cmd/link.go` and `cmd/unlink.go` | DONE | Both now route args through `ResolveArgs()` before calling `LinkPackages`/`UnlinkPackages`. Added `Long` descriptions to cobra commands documenting the new path support. |
+| 4 | Update `README.md` | DONE | Added `dloom link .`, `dloom link ~/dotfiles/`, `dloom unlink .` examples to Quick Start, Usage, and Project Structure sections. |
+| 5 | Create `CLAUDE.md` | DONE | Project guide with build commands, architecture overview, config search order, and conventions. |
+| 6 | Build and test | DONE | Clean build, all 16 tests pass, manual dry-run verification of all scenarios. |
+
+## Files Changed
+
+### New files
+- **`internal/resolve.go`** — Core argument resolution logic (165 lines)
+- **`internal/resolve_test.go`** — Comprehensive test suite (370 lines)
+- **`CLAUDE.md`** — Project guide for future sessions
+
+### Modified files
+- **`cmd/link.go`** — Added `ResolveArgs` call, updated command description
+- **`cmd/unlink.go`** — Same changes as link.go
+- **`README.md`** — Documented new `link .` and `unlink .` behavior
+
+### Unchanged files
+- `internal/config.go` — No changes needed; `dloom` dir stays as a valid linkable package
+- `cmd/root.go` — No changes needed; CLI flags already merged into config by `PersistentPreRunE`
+- `internal/link.go`, `internal/unlink.go` — Untouched; resolution happens before they're called
+
+## Implementation Note: macOS Symlink Resolution
+
+During testing, discovered that macOS resolves `/var` → `/private/var` differently depending on whether you use `filepath.Abs` (preserves symlinks) vs `os.Getwd` (resolves them). This caused path comparison failures in tests. Fixed by using `filepath.EvalSymlinks` on both the resolved argument path and source_dir before comparing.
+
+## Verification Results
+
+```
+$ cd /tmp/test-dotfiles && dloom -d link .
+[INFO]: Skipping root-level file (not in a package): .gitignore
+[INFO]: Skipping root-level file (not in a package): README.md
+[DRY RUN]: Would link: ~/.gitconfig -> /tmp/test-dotfiles/git/.gitconfig
+[DRY RUN]: Would link: ~/.vimrc -> /tmp/test-dotfiles/vim/.vimrc
+[DRY RUN]: Would link: ~/.zshrc -> /tmp/test-dotfiles/zsh/.zshrc
+
+$ cd /tmp && dloom -d link /tmp/test-dotfiles/
+# Same output — correctly enumerates packages from absolute path
+
+$ cd /tmp/test-dotfiles && dloom -d link vim
+[DRY RUN]: Would link: ~/.vimrc -> /tmp/test-dotfiles/vim/.vimrc
+# Bare name — unchanged behavior
+
+$ cd /tmp/test-dotfiles && dloom -d unlink .
+[INFO]: Skipping root-level file (not in a package): .gitignore
+[INFO]: Skipping root-level file (not in a package): README.md
+# Unlink works symmetrically
+```

--- a/internal/resolve.go
+++ b/internal/resolve.go
@@ -1,0 +1,218 @@
+package internal
+
+import (
+	"fmt"
+	"github.com/dloomorg/dloom/internal/logging"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ArgKind classifies a CLI argument as either a bare package name or a path.
+type ArgKind int
+
+const (
+	// ArgBare is a bare package name like "vim" or "zsh"
+	ArgBare ArgKind = iota
+	// ArgPath is a filesystem path like ".", "..", "~/dotfiles", "/abs/path"
+	ArgPath
+)
+
+// ClassifyArg determines whether a raw argument is a bare package name or a path.
+func ClassifyArg(arg string) ArgKind {
+	if arg == "." || arg == ".." {
+		return ArgPath
+	}
+	if strings.HasPrefix(arg, "/") || strings.HasPrefix(arg, "~") ||
+		strings.HasPrefix(arg, "./") || strings.HasPrefix(arg, "../") {
+		return ArgPath
+	}
+	if strings.Contains(arg, "/") {
+		return ArgPath
+	}
+	return ArgBare
+}
+
+// isAbsoluteArg returns true if the raw argument is an absolute or home-relative
+// path (starts with "/" or "~"), as opposed to a relative path like "./" or "../".
+func isAbsoluteArg(arg string) bool {
+	return strings.HasPrefix(arg, "/") || strings.HasPrefix(arg, "~")
+}
+
+// ResolveArgs takes raw CLI arguments and the current config, classifies each,
+// resolves paths, and returns a deduplicated list of package names along with
+// the effective Config to use (which may differ from the input cfg if an
+// external dotfiles directory was specified).
+//
+// Path resolution strategy:
+//   - "." or paths that resolve to source_dir → enumerate all packages
+//   - Relative paths ("./vim", "vim/", "../foo") that are children of source_dir
+//     → extract the relative portion as a package name
+//   - Absolute/home paths ("/abs/path", "~/dotfiles") → always treated as a
+//     dotfiles root to enumerate, even if technically a child of source_dir.
+//     This prevents surprising behavior when source_dir defaults to CWD.
+func ResolveArgs(args []string, cfg *Config, logger *logging.Logger) ([]string, *Config, error) {
+	effectiveCfg := cfg
+	seen := make(map[string]bool)
+	var packages []string
+	var overrideDir string
+
+	for _, arg := range args {
+		kind := ClassifyArg(arg)
+
+		if kind == ArgBare {
+			if !seen[arg] {
+				seen[arg] = true
+				packages = append(packages, arg)
+			}
+			continue
+		}
+
+		// It's a path — resolve to absolute
+		absPath, err := ExpandPath(arg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to resolve path %s: %w", arg, err)
+		}
+		absPath = filepath.Clean(absPath)
+
+		// Verify the path exists and is a directory
+		info, err := os.Stat(absPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil, fmt.Errorf("directory does not exist: %s", absPath)
+			}
+			return nil, nil, fmt.Errorf("failed to access %s: %w", absPath, err)
+		}
+		if !info.IsDir() {
+			return nil, nil, fmt.Errorf("not a directory: %s", absPath)
+		}
+
+		sourceDir := filepath.Clean(cfg.SourceDir)
+
+		// Resolve symlinks for both paths to ensure consistent comparison
+		// (e.g., on macOS /var -> /private/var)
+		absPathResolved, err := filepath.EvalSymlinks(absPath)
+		if err != nil {
+			absPathResolved = absPath
+		}
+		sourceDirResolved, err := filepath.EvalSymlinks(sourceDir)
+		if err != nil {
+			sourceDirResolved = sourceDir
+		}
+
+		if absPathResolved == sourceDirResolved {
+			// Path equals source_dir — enumerate all packages
+			pkgs, err := EnumeratePackages(sourceDir, cfg.IgnorePackages, logger)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to enumerate packages in %s: %w", sourceDir, err)
+			}
+			for _, pkg := range pkgs {
+				if !seen[pkg] {
+					seen[pkg] = true
+					packages = append(packages, pkg)
+				}
+			}
+		} else if !isAbsoluteArg(arg) && isSubdirOf(absPathResolved, sourceDirResolved) {
+			// Relative path that is a child of source_dir — extract package name.
+			// Only relative args (./vim, vim/, ../x) get this treatment;
+			// absolute paths always go to the external-directory branch below.
+			relName, err := filepath.Rel(sourceDirResolved, absPathResolved)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to compute relative path: %w", err)
+			}
+			if !seen[relName] {
+				seen[relName] = true
+				packages = append(packages, relName)
+			}
+		} else {
+			// External directory — override source_dir and enumerate packages.
+			if overrideDir != "" && overrideDir != absPath {
+				return nil, nil, fmt.Errorf("conflicting source directories: %s and %s", overrideDir, absPath)
+			}
+			overrideDir = absPath
+
+			// Load config from the external directory if available
+			externalConfigPath := filepath.Join(absPath, "dloom", "config.yaml")
+			newCfg, err := LoadConfig(externalConfigPath, logger)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to load config from %s: %w", absPath, err)
+			}
+			newCfg.SourceDir = absPath
+
+			// Preserve CLI flag overrides from the original config
+			newCfg.Force = cfg.Force
+			newCfg.Verbose = cfg.Verbose
+			newCfg.DryRun = cfg.DryRun
+			if cfg.TargetDir != "" {
+				newCfg.TargetDir = cfg.TargetDir
+			}
+
+			effectiveCfg = newCfg
+
+			// Enumerate packages from the external directory
+			pkgs, err := EnumeratePackages(absPath, effectiveCfg.IgnorePackages, logger)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to enumerate packages in %s: %w", absPath, err)
+			}
+			for _, pkg := range pkgs {
+				if !seen[pkg] {
+					seen[pkg] = true
+					packages = append(packages, pkg)
+				}
+			}
+		}
+	}
+
+	return packages, effectiveCfg, nil
+}
+
+// EnumeratePackages lists top-level directories in sourceDir that are not
+// in the ignore list. Root-level files are skipped with an info log.
+// Returns sorted package names.
+func EnumeratePackages(sourceDir string, ignorePackages []string, logger *logging.Logger) ([]string, error) {
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %w", sourceDir, err)
+	}
+
+	var packages []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			logger.LogInfo("Skipping root-level file (not in a package): %s", entry.Name())
+			continue
+		}
+
+		name := entry.Name()
+		if shouldIgnoreName(name, ignorePackages) {
+			continue
+		}
+
+		packages = append(packages, name)
+	}
+
+	sort.Strings(packages)
+	return packages, nil
+}
+
+// shouldIgnoreName checks if a name matches any entry in the ignore list.
+// Uses the same suffix-matching logic as Config.ShouldIgnorePackage.
+func shouldIgnoreName(name string, ignorePackages []string) bool {
+	for _, ignored := range ignorePackages {
+		if strings.HasSuffix(name, ignored) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSubdirOf checks if child is a subdirectory of parent.
+// Both paths must be absolute and clean.
+func isSubdirOf(child, parent string) bool {
+	// Ensure parent ends with separator for prefix matching
+	parentPrefix := parent
+	if !strings.HasSuffix(parentPrefix, string(filepath.Separator)) {
+		parentPrefix += string(filepath.Separator)
+	}
+	return strings.HasPrefix(child, parentPrefix)
+}

--- a/internal/resolve_test.go
+++ b/internal/resolve_test.go
@@ -1,0 +1,397 @@
+package internal
+
+import (
+	"github.com/dloomorg/dloom/internal/logging"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClassifyArg(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want ArgKind
+	}{
+		{"vim", ArgBare},
+		{"zsh", ArgBare},
+		{"my-package", ArgBare},
+		{".", ArgPath},
+		{"..", ArgPath},
+		{"./vim", ArgPath},
+		{"../dotfiles", ArgPath},
+		{"/absolute/path", ArgPath},
+		{"~/dotfiles", ArgPath},
+		{"~/dotfiles/vim", ArgPath},
+		{"vim/", ArgPath},
+		{"sub/dir", ArgPath},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			got := ClassifyArg(tt.arg)
+			if got != tt.want {
+				t.Errorf("ClassifyArg(%q) = %d, want %d", tt.arg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnumeratePackages(t *testing.T) {
+	// Create temp directory structure
+	tmpDir := t.TempDir()
+
+	// Create package directories
+	for _, dir := range []string{"vim", "zsh", "git", ".git", ".idea"} {
+		if err := os.Mkdir(filepath.Join(tmpDir, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Create root-level files
+	for _, f := range []string{".zshrc", "README.md", ".gitignore"} {
+		if err := os.WriteFile(filepath.Join(tmpDir, f), []byte("test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	logger := &logging.Logger{UseColors: false}
+	ignorePackages := []string{".git", ".idea", ".gitignore"}
+
+	packages, err := EnumeratePackages(tmpDir, ignorePackages, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should return sorted package names, excluding ignored dirs and files
+	expected := []string{"git", "vim", "zsh"}
+	if len(packages) != len(expected) {
+		t.Fatalf("got %d packages %v, want %d packages %v", len(packages), packages, len(expected), expected)
+	}
+	for i, pkg := range packages {
+		if pkg != expected[i] {
+			t.Errorf("packages[%d] = %q, want %q", i, pkg, expected[i])
+		}
+	}
+}
+
+func TestEnumeratePackages_EmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	logger := &logging.Logger{UseColors: false}
+
+	packages, err := EnumeratePackages(tmpDir, nil, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packages) != 0 {
+		t.Errorf("expected empty packages, got %v", packages)
+	}
+}
+
+func TestEnumeratePackages_OnlyFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Only root-level files, no package dirs
+	for _, f := range []string{".zshrc", ".gitconfig"} {
+		os.WriteFile(filepath.Join(tmpDir, f), []byte("test"), 0644)
+	}
+
+	logger := &logging.Logger{UseColors: false}
+	packages, err := EnumeratePackages(tmpDir, nil, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packages) != 0 {
+		t.Errorf("expected no packages (only root files), got %v", packages)
+	}
+}
+
+func TestResolveArgs_BareName(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{SourceDir: tmpDir}
+	logger := &logging.Logger{UseColors: false}
+
+	packages, effectiveCfg, err := ResolveArgs([]string{"vim", "zsh"}, cfg, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if effectiveCfg != cfg {
+		t.Error("expected config to be unchanged for bare names")
+	}
+	expected := []string{"vim", "zsh"}
+	if len(packages) != len(expected) {
+		t.Fatalf("got %v, want %v", packages, expected)
+	}
+	for i, pkg := range packages {
+		if pkg != expected[i] {
+			t.Errorf("packages[%d] = %q, want %q", i, pkg, expected[i])
+		}
+	}
+}
+
+func TestResolveArgs_Dot(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Create package dirs
+	for _, dir := range []string{"vim", "zsh", ".git"} {
+		os.Mkdir(filepath.Join(tmpDir, dir), 0755)
+	}
+	// Create a root file (should be skipped)
+	os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("test"), 0644)
+
+	// source_dir must be absolute (as done in cmd/root.go)
+	cfg := &Config{
+		SourceDir:      tmpDir,
+		IgnorePackages: []string{".git"},
+	}
+	logger := &logging.Logger{UseColors: false}
+
+	// Change to tmpDir so "." resolves to source_dir
+	oldWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(oldWd)
+
+	packages, _, err := ResolveArgs([]string{"."}, cfg, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []string{"vim", "zsh"}
+	if len(packages) != len(expected) {
+		t.Fatalf("got %v, want %v", packages, expected)
+	}
+	for i, pkg := range packages {
+		if pkg != expected[i] {
+			t.Errorf("packages[%d] = %q, want %q", i, pkg, expected[i])
+		}
+	}
+}
+
+func TestResolveArgs_SubdirOfSourceDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	vimDir := filepath.Join(tmpDir, "vim")
+	os.Mkdir(vimDir, 0755)
+
+	cfg := &Config{SourceDir: tmpDir}
+	logger := &logging.Logger{UseColors: false}
+
+	// Use relative path — cd into sourceDir and use ./vim
+	oldWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(oldWd)
+
+	packages, _, err := ResolveArgs([]string{"./vim"}, cfg, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(packages) != 1 || packages[0] != "vim" {
+		t.Errorf("got %v, want [vim]", packages)
+	}
+}
+
+func TestResolveArgs_AbsolutePathEnumerates(t *testing.T) {
+	// Absolute paths should always be treated as dotfiles roots,
+	// even if they're technically children of source_dir.
+	tmpDir := t.TempDir()
+	childDir := filepath.Join(tmpDir, "my-dotfiles")
+	os.Mkdir(childDir, 0755)
+	os.Mkdir(filepath.Join(childDir, "vim"), 0755)
+	os.Mkdir(filepath.Join(childDir, "zsh"), 0755)
+
+	cfg := &Config{
+		SourceDir:      tmpDir,
+		IgnorePackages: []string{".git"},
+	}
+	logger := &logging.Logger{UseColors: false}
+
+	packages, effectiveCfg, err := ResolveArgs([]string{childDir}, cfg, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should enumerate packages from the child dir, not extract "my-dotfiles" as a package
+	if effectiveCfg.SourceDir != childDir {
+		t.Errorf("expected SourceDir %s, got %s", childDir, effectiveCfg.SourceDir)
+	}
+	expected := []string{"vim", "zsh"}
+	if len(packages) != len(expected) {
+		t.Fatalf("got %v, want %v", packages, expected)
+	}
+	for i, pkg := range packages {
+		if pkg != expected[i] {
+			t.Errorf("packages[%d] = %q, want %q", i, pkg, expected[i])
+		}
+	}
+}
+
+func TestResolveArgs_ExternalDirWithConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Create external dotfiles dir with config
+	externalDir := filepath.Join(tmpDir, "external-dotfiles")
+	os.MkdirAll(filepath.Join(externalDir, "dloom"), 0755)
+	os.WriteFile(filepath.Join(externalDir, "dloom", "config.yaml"), []byte("verbose: true\n"), 0644)
+	// Create package dirs in external
+	os.Mkdir(filepath.Join(externalDir, "tmux"), 0755)
+	os.Mkdir(filepath.Join(externalDir, "bash"), 0755)
+
+	cfg := &Config{
+		SourceDir:      filepath.Join(tmpDir, "original"),
+		IgnorePackages: []string{".git"},
+	}
+	logger := &logging.Logger{UseColors: false}
+
+	packages, effectiveCfg, err := ResolveArgs([]string{externalDir}, cfg, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if effectiveCfg.SourceDir != externalDir {
+		t.Errorf("expected SourceDir to be %s, got %s", externalDir, effectiveCfg.SourceDir)
+	}
+
+	expected := []string{"bash", "dloom", "tmux"}
+	if len(packages) != len(expected) {
+		t.Fatalf("got %v, want %v", packages, expected)
+	}
+	for i, pkg := range packages {
+		if pkg != expected[i] {
+			t.Errorf("packages[%d] = %q, want %q", i, pkg, expected[i])
+		}
+	}
+}
+
+func TestResolveArgs_ExternalDirWithoutConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	externalDir := filepath.Join(tmpDir, "simple-dotfiles")
+	os.Mkdir(externalDir, 0755)
+	os.Mkdir(filepath.Join(externalDir, "vim"), 0755)
+
+	cfg := &Config{
+		SourceDir:      filepath.Join(tmpDir, "original"),
+		IgnorePackages: []string{".git"},
+	}
+	logger := &logging.Logger{UseColors: false}
+
+	packages, effectiveCfg, err := ResolveArgs([]string{externalDir}, cfg, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if effectiveCfg.SourceDir != externalDir {
+		t.Errorf("expected SourceDir to be %s, got %s", externalDir, effectiveCfg.SourceDir)
+	}
+	if len(packages) != 1 || packages[0] != "vim" {
+		t.Errorf("got %v, want [vim]", packages)
+	}
+}
+
+func TestResolveArgs_NonexistentPath(t *testing.T) {
+	cfg := &Config{SourceDir: "/tmp/nonexistent-source"}
+	logger := &logging.Logger{UseColors: false}
+
+	_, _, err := ResolveArgs([]string{"/tmp/nonexistent-path-xyz"}, cfg, logger)
+	if err == nil {
+		t.Error("expected error for nonexistent path")
+	}
+}
+
+func TestResolveArgs_Deduplication(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, dir := range []string{"vim", "zsh"} {
+		os.Mkdir(filepath.Join(tmpDir, dir), 0755)
+	}
+
+	cfg := &Config{
+		SourceDir:      tmpDir,
+		IgnorePackages: []string{".git"},
+	}
+	logger := &logging.Logger{UseColors: false}
+
+	// Change to tmpDir so "." resolves to source_dir
+	oldWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(oldWd)
+
+	// "." expands to [vim, zsh], then "vim" is also passed — should be deduplicated
+	packages, _, err := ResolveArgs([]string{".", "vim"}, cfg, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []string{"vim", "zsh"}
+	if len(packages) != len(expected) {
+		t.Fatalf("got %v, want %v", packages, expected)
+	}
+}
+
+func TestResolveArgs_TrailingSlash(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Mkdir(filepath.Join(tmpDir, "vim"), 0755)
+
+	cfg := &Config{SourceDir: tmpDir}
+	logger := &logging.Logger{UseColors: false}
+
+	// cd into sourceDir and use relative path with trailing slash
+	oldWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(oldWd)
+
+	packages, _, err := ResolveArgs([]string{"./vim/"}, cfg, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(packages) != 1 || packages[0] != "vim" {
+		t.Errorf("got %v, want [vim]", packages)
+	}
+}
+
+func TestResolveArgs_ConflictingOverrides(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir1 := filepath.Join(tmpDir, "dotfiles1")
+	dir2 := filepath.Join(tmpDir, "dotfiles2")
+	os.Mkdir(dir1, 0755)
+	os.Mkdir(dir2, 0755)
+
+	cfg := &Config{SourceDir: filepath.Join(tmpDir, "original")}
+	logger := &logging.Logger{UseColors: false}
+
+	_, _, err := ResolveArgs([]string{dir1, dir2}, cfg, logger)
+	if err == nil {
+		t.Error("expected error for conflicting source directories")
+	}
+}
+
+func TestResolveArgs_NotADirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "somefile")
+	os.WriteFile(filePath, []byte("test"), 0644)
+
+	cfg := &Config{SourceDir: tmpDir}
+	logger := &logging.Logger{UseColors: false}
+
+	_, _, err := ResolveArgs([]string{filePath}, cfg, logger)
+	if err == nil {
+		t.Error("expected error for non-directory path")
+	}
+}
+
+func Test_isSubdirOf(t *testing.T) {
+	tests := []struct {
+		child  string
+		parent string
+		want   bool
+	}{
+		{"/home/user/dotfiles/vim", "/home/user/dotfiles", true},
+		{"/home/user/dotfiles/vim/colors", "/home/user/dotfiles", true},
+		{"/home/user/dotfiles", "/home/user/dotfiles", false},
+		{"/home/user/other", "/home/user/dotfiles", false},
+		{"/home/user/dotfiles-extra", "/home/user/dotfiles", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.child+"_in_"+tt.parent, func(t *testing.T) {
+			got := isSubdirOf(tt.child, tt.parent)
+			if got != tt.want {
+				t.Errorf("isSubdirOf(%q, %q) = %v, want %v", tt.child, tt.parent, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
  ## Summary

  `dloom link` and `dloom unlink` now support paths in addition to bare package names:

  - `dloom link .` — link all packages in the current dotfiles directory
  - `dloom link ./vim` — resolve relative path to a package name
  - `dloom unlink .` — unlink all packages

  Previously, `.` was treated as a package name, causing `GetSourcePath(".")` to resolve
  to `source_dir` itself and walk the entire dotfiles root as a flat package — ignoring
  all `link_overrides` configs. Absolute paths like `~/projects/dotfiles/` were concatenated
  with `source_dir`, producing nonsensical paths.

  ## Changes

  - **`internal/resolve.go`** — New argument resolution layer. Classifies args as bare names
    vs paths, resolves paths to enumerate packages or extract package names, handles external
    dotfiles directories (with config loading), deduplicates, and validates.
  - **`internal/resolve_test.go`** — 16 tests covering classification, enumeration, path
    resolution edge cases (dot, subdirs, external dirs, trailing slashes, conflicts).
  - **`cmd/link.go`**, **`cmd/unlink.go`** — Route args through `ResolveArgs()` before
    calling `LinkPackages`/`UnlinkPackages`.
  - **`README.md`** — Documents new `link .` and `unlink .` usage.

  ## Design

  Follows the Stow model: packages (directories) are the only unit of linking.
  Root-level files in source_dir are skipped with an info message. No new flags needed.

  | Argument | Behavior |
  |---|---|
  | `vim` | Bare name — unchanged |
  | `.` | Enumerate all package dirs in source_dir |
  | `./vim`, `vim/` | Relative path — extract package name |
  | `/abs/path`, `~/path` | External dotfiles root — load config, enumerate |

  ## Test plan

  - [x] `make build` compiles
  - [x] `make test` — 16 new tests pass
  - [x] `dloom -d link .` from dotfiles root enumerates all packages
  - [x] `dloom -d link /path/to/dotfiles/` from another directory works
  - [x] `dloom link vim` unchanged behavior
  - [x] `dloom -d unlink .` works symmetrically
  - [x] Root-level files produce info messages